### PR TITLE
Fixed ChromeCast not being able to open apps

### DIFF
--- a/lib/Finder.js
+++ b/lib/Finder.js
@@ -49,7 +49,7 @@ Finder.prototype.add = function(msg, info){
 		var parsedBody = xml2json.toJson(res.text, {object: true});
 		
 		// Get app base url
-		urlParts.pathname = urlParts.path = url.parse(res.headers['application-url']).path+"/";
+		urlParts.pathname = urlParts.path = url.parse(res.headers['application-url']).path;
 
 		var deviceArgs = {
 			name: parsedBody.root.device.friendlyName,


### PR DESCRIPTION
I have no idea why that / was there but it causes the ChromeCast to put
two /s at the end of the appBase URL causing redirect loops when launching
an app. This fixes #6.
